### PR TITLE
fuzzy-wuzzy replaced by rapidfuzz

### DIFF
--- a/pdf_manager.py
+++ b/pdf_manager.py
@@ -7,7 +7,7 @@ import pdfplumber
 import pytesseract
 from PIL import Image
 from PyPDF2 import PdfReader, PdfWriter
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from pdf2image import convert_from_path
 from pdfminer.high_level import extract_pages
 from pdfminer.layout import LTChar, LTTextContainer, LTTextBoxHorizontal

--- a/poetry.lock
+++ b/poetry.lock
@@ -680,4 +680,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0bc919911b8687b22c2b9c7d23cb446ef6b87c61589f19ec304b316055d403a5"
+content-hash = "461c6c62a98858026fabf4a90e268077d73a6114fc12817e8c87b1cf40926d33"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytesseract = "^0.3.10"
 pyprojroot = "^0.3.0"
 fuzzywuzzy = "^0.18.0"
 python-levenshtein = "^0.23.0"
+rapidfuzz = "^3.5.2"
 
 
 [build-system]


### PR DESCRIPTION
`rapidfuzz` offers faster execution times and more efficient memory usage compared to `fuzzywuzzy`. Given the volume of text processing our application performs, particularly in the context of PDF parsing and data extraction, this change is expected to yield considerable performance improvements.